### PR TITLE
Dev branch

### DIFF
--- a/gamemodes/prop_hunt/gamemode/cl_tauntwindow.lua
+++ b/gamemodes/prop_hunt/gamemode/cl_tauntwindow.lua
@@ -48,10 +48,6 @@ local function MainFrame()
 	window.scrollpanel:Dock(FILL)
 	window.scrollpanel.VBar.Scroll = LocalPlayer():GetNWInt("tauntWindowScrolling",0)
 
-	function window.scrollpanel:Paint(w,h)
-		draw.RoundedBox(1, 0, 0, w, h, Color(255,0,0,255))
-	end
-
 	window.list = vgui.Create("DListView", window.scrollpanel)
 	window.list:SetMultiSelect(false)
 	window.list:AddColumn("soundlist") -- does nothing because header is invisible.


### PR DESCRIPTION
General QOL features on the taunt window :
-Allow to close the taunt window with the same key that opens it
-Save the category you browsing
-Save the state of the scrollbar, to explain better, when you where playing a taunt at the bottom of the list, you had to go back to it, now it saves the position on every action that can close the window.