### PR TITLE
Open & Close propchooser with same key

### DIFF
--- a/gamemodes/prop_hunt/gamemode/plugins/propmenu/cl_propchoose.lua
+++ b/gamemodes/prop_hunt/gamemode/plugins/propmenu/cl_propchoose.lua
@@ -62,108 +62,125 @@ function PCR.WindowControl.MainFrame( ls )
 	end
 	
 	if LocalPlayer():Alive() && LocalPlayer():Team() == TEAM_PROPS then
-		local str = "0"
-		local uselimit = LocalPlayer():CheckUsage()
-		
-		if uselimit == 0 then
-			chat.AddText(Color(10,235,30), "[PHX Prop Menu]", Color(220,220,220), PHX:FTranslate("PCR_CL_LIMIT"))
-			return
-		end
-		if uselimit <= -1 then str = PHX:Translate("PCR_UNLIMIT_TEXT") end
-		if uselimit > 0 then str = tostring(uselimit) end
-		
-		local about = math.random(1,2)
-		
-		f.frame = vgui.Create("DFrame")
-		f.frame:SetPos(30,25)
-		f.frame:SetSize(400,ScrH()-45)
-		f.frame:SetTitle(PHX:FTranslate("PCR_WINDOW_TITLE"))
-		f.frame:SetVisible(true)
-		f.frame:ShowCloseButton(true)
-		f.frame:SetMouseInputEnabled(true)
-		f.frame:SetKeyboardInputEnabled(true)
-		
-		f.frame:SetDraggable(true)
-		
-		-- top panel --
-		f.panel = vgui.Create("DPanel",f.frame)
-		f.panel:Dock(TOP)
-		f.panel:SetSize(0,72)
-		f.panel:DockMargin(8,4,8,0)
-		f.panel:SetBackgroundColor(Color(64,64,64))
-		
-		-- container of top panel --	
-		local font = "Trebuchet24"
-		local font2 = "HudHintTextLarge"
-		f.panel.PaintOver = function(self,w,h)
-			surface.SetFont(font)
-			draw.DrawText(PHX:FTranslate("PCR_HEADER_TOP"),font2,w/2,h/2-32,Color(200,200,200),TEXT_ALIGN_CENTER)
-			draw.DrawText(PHX:FTranslate("PCR_HEADER_MID", str),font,w/2,h/2-16,Color(255,255,30),TEXT_ALIGN_CENTER)
-			draw.DrawText(PHX:FTranslate("PCR_HEADER_BOTTOM"),font2,w/2,h/2+12,Color(200,200,200),TEXT_ALIGN_CENTER)
-		end
-		
-		-- body panel --
-		f.body = vgui.Create("DPanel",f.frame)
-		f.body:Dock(FILL)
-		f.body:DockMargin(8,4,8,4)
-		
-		f.gridscrl = vgui.Create("DScrollPanel", f.body)
-		f.gridscrl:Dock(FILL)
-		f.gridscrl:DockMargin(4,2,4,2)
-		
-		-- container of body --
-		f.grid = vgui.Create("DGrid",f.gridscrl)
-		f.grid:SetPos(10,10)
-		f.grid:SetSize(f.gridscrl:GetWide(),f.gridscrl:GetTall())
-		f.grid:SetCols(5)
-		f.grid:SetColWide(67)
-		f.grid:SetRowHeight(66)
-		f.grid:SetVerticalScrollbarEnabled(true)
-		
-		for _,p in pairs(ls) do
-			local pan = vgui.Create("DPanel")
-			local tooltext = PHX:FTranslate( "PCR_CL_TOOLTIP_MODEL", p )
-			pan:SetSize(64,64)
-			if table.HasValue( PHX.BANNED_PROP_MODELS, p ) then
-				tooltext = PHX:FTranslate("PCR_CL_TOOLTIP_BANNED")
-				pan:SetBackgroundColor(Color(120,20,20))
-			else
-				pan:SetBackgroundColor(Color(100,100,100))
+
+		--Ugly, but how the frame is made it's the only way I found, idk how to do better
+		if !f.frame || tostring(f.frame) == "[NULL Panel]" then
+
+			f.frame = nil
+			f.grid = nil
+			f.gridscrl = nil
+			f.body = nil
+			f.panel = nil
+			local str = "0"
+			local uselimit = LocalPlayer():CheckUsage()
+			
+			if uselimit == 0 then
+				chat.AddText(Color(10,235,30), "[PHX Prop Menu]", Color(220,220,220), PHX:FTranslate("PCR_CL_LIMIT"))
+				return
+			end
+			if uselimit <= -1 then str = PHX:Translate("PCR_UNLIMIT_TEXT") end
+			if uselimit > 0 then str = tostring(uselimit) end
+			
+			local about = math.random(1,2)
+			
+			f.frame = vgui.Create("DFrame")
+			f.frame:SetPos(30,25)
+			f.frame:SetSize(400,ScrH()-45)
+			f.frame:SetTitle(PHX:FTranslate("PCR_WINDOW_TITLE"))
+			f.frame:SetVisible(true)
+			f.frame:ShowCloseButton(true)
+			f.frame:SetMouseInputEnabled(true)
+			f.frame:SetKeyboardInputEnabled(true)
+			
+			f.frame:SetDraggable(true)
+			
+			-- top panel --
+			f.panel = vgui.Create("DPanel",f.frame)
+			f.panel:Dock(TOP)
+			f.panel:SetSize(0,72)
+			f.panel:DockMargin(8,4,8,0)
+			f.panel:SetBackgroundColor(Color(64,64,64))
+			
+			-- container of top panel --	
+			local font = "Trebuchet24"
+			local font2 = "HudHintTextLarge"
+			f.panel.PaintOver = function(self,w,h)
+				surface.SetFont(font)
+				draw.DrawText(PHX:FTranslate("PCR_HEADER_TOP"),font2,w/2,h/2-32,Color(200,200,200),TEXT_ALIGN_CENTER)
+				draw.DrawText(PHX:FTranslate("PCR_HEADER_MID", str),font,w/2,h/2-16,Color(255,255,30),TEXT_ALIGN_CENTER)
+				draw.DrawText(PHX:FTranslate("PCR_HEADER_BOTTOM"),font2,w/2,h/2+12,Color(200,200,200),TEXT_ALIGN_CENTER)
 			end
 			
-			local icon = vgui.Create("SpawnIcon",pan)
-			icon:SetModel(Model(p))
-			icon:SetSize(64,64)
-			icon:SetToolTip(tooltext)
+			-- body panel --
+			f.body = vgui.Create("DPanel",f.frame)
+			f.body:Dock(FILL)
+			f.body:DockMargin(8,4,8,4)
 			
-			icon.DoClick = function()
-				net.Start("pcr.SetMetheProp")
-				net.WriteString(p)
-				net.SendToServer()
-				f.frame:Close()
-			end
+			f.gridscrl = vgui.Create("DScrollPanel", f.body)
+			f.gridscrl:Dock(FILL)
+			f.gridscrl:DockMargin(4,2,4,2)
 			
-			if LocalPlayer():CheckUserGroup() or LocalPlayer():IsSuperAdmin() then
-				icon.DoRightClick = function()
-					local m = DermaMenu()
-					m:AddOption("Copy Model", function() SetClipboardText( p ) end):SetIcon("icon16/page_copy.png")
-					m:Open()
-					
-					-- This is place holder. The idea is that, you can mark and add prop ban from here.
-					-- This idea scrapped, but will be included later in future update/PH:Z
+			-- container of body --
+			f.grid = vgui.Create("DGrid",f.gridscrl)
+			f.grid:SetPos(10,10)
+			f.grid:SetSize(f.gridscrl:GetWide(),f.gridscrl:GetTall())
+			f.grid:SetCols(5)
+			f.grid:SetColWide(67)
+			f.grid:SetRowHeight(66)
+			f.grid:SetVerticalScrollbarEnabled(true)
+			
+			for _,p in pairs(ls) do
+				local pan = vgui.Create("DPanel")
+				local tooltext = PHX:FTranslate( "PCR_CL_TOOLTIP_MODEL", p )
+				pan:SetSize(64,64)
+				if table.HasValue( PHX.BANNED_PROP_MODELS, p ) then
+					tooltext = PHX:FTranslate("PCR_CL_TOOLTIP_BANNED")
+					pan:SetBackgroundColor(Color(120,20,20))
+				else
+					pan:SetBackgroundColor(Color(100,100,100))
 				end
+				
+				local icon = vgui.Create("SpawnIcon",pan)
+				icon:SetModel(Model(p))
+				icon:SetSize(64,64)
+				icon:SetToolTip(tooltext)
+				
+				icon.DoClick = function()
+					net.Start("pcr.SetMetheProp")
+					net.WriteString(p)
+					net.SendToServer()
+					f.frame:Close()
+				end
+				
+				if LocalPlayer():CheckUserGroup() or LocalPlayer():IsSuperAdmin() then
+					icon.DoRightClick = function()
+						local m = DermaMenu()
+						m:AddOption("Copy Model", function() SetClipboardText( p ) end):SetIcon("icon16/page_copy.png")
+						m:Open()
+						
+						-- This is place holder. The idea is that, you can mark and add prop ban from here.
+						-- This idea scrapped, but will be included later in future update/PH:Z
+					end
+				end
+				
+				f.grid:AddItem(pan)
 			end
 			
-			f.grid:AddItem(pan)
+			f.currentlyOpen = true
+			f.frame.OnClose = function()
+				f.currentlyOpen = false
+			end
+			
+			f.frame:MakePopup()
+			f.frame:SetKeyboardInputEnabled(false)
 		end
-		
-		f.currentlyOpen = true
-		f.frame.OnClose = function()
-			f.currentlyOpen = false
+
+		--Open the menu if not opened, close it if it is
+		if !f.frame:IsVisible() then
+			f.frame:SetVisible(true)
+		else
+			f.frame:SetVisible(false)
 		end
-		
-		f.frame:MakePopup()
-		f.frame:SetKeyboardInputEnabled(false)
 	else
 	
 		chat.AddText(Color(10,235,30), "[PHX Prop Menu]", Color(220,220,220), PHX:FTranslate("PCR_CL_MENU_NOTREADY"))
@@ -172,9 +189,7 @@ function PCR.WindowControl.MainFrame( ls )
 end
 
 function PCR:AddProps()
-	if (not f.currentlyOpen) then
-		self.WindowControl.MainFrame(self.PropList)
-	end
+	self.WindowControl.MainFrame(self.PropList)
 end
 
 concommand.Add("ph_prop_menu", function()


### PR DESCRIPTION
Small functionality but can help.
It allow to open and close the propchooser with the same key, helpful when u get shot, only have to press a key 😃 

Github counts many additions and many deletions but I only opened a new condition and put the whole thing inside.

Lines added :
-67
-69 to 73
-179 to 183

And deleted at the end the condition f.currentlyOpen (after line 191)