### PR TITLE
Lint - Fix mistyped IF on team item spawner Initialize

### DIFF
--- a/gamemodes/prop_hunt/entities/entities/ph_teamitem_spawner.lua
+++ b/gamemodes/prop_hunt/entities/entities/ph_teamitem_spawner.lua
@@ -14,7 +14,7 @@ if SERVER then
 end
 
 function ENT:Initialize()
-	if (not cvEnableTeamSpawner:GetBool())
+	if not cvEnableTeamSpawner:GetBool() then
 		if SERVER then self:Remove(); end
 		return
 	end


### PR DESCRIPTION
Fixing:
![image](https://github.com/user-attachments/assets/22112f33-927a-4622-acbd-85cd386f8c93)
